### PR TITLE
Adds response headers to results pipeline.

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -965,6 +965,8 @@ export class CmdletClass extends Class {
 
             //  let's just return the result object (or unwrapped result object)
             yield `WriteObject(${outValue});`;
+            yield 'var headers = Microsoft.Graph.PowerShell.ResponseHeader.Helper.ResponseHeaderHelper.ToResponseHeader(responseMessage);'
+            yield 'WriteObject(headers);'
             return;
           }
 
@@ -1007,6 +1009,8 @@ export class CmdletClass extends Class {
             // no return type. Let's just return ... true?
             yield 'WriteObject(true);';
           });
+          yield 'var headers = Microsoft.Graph.PowerShell.ResponseHeader.Helper.ResponseHeaderHelper.ToResponseHeader(responseMessage);'
+          yield 'WriteObject(headers);'
         });
         $this.add(responseMethod);
       }

--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyTypes.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyTypes.cs
@@ -66,6 +66,11 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             ProfileName = profileName;
             Variants = variants;
             Console.WriteLine($"module: {moduleName} -- cmdlet: {cmdletName} -- profileName: {profileName}");
+            foreach (Variant item in variants)
+            {
+                Console.WriteLine($"VariantName: {item.VariantName}");
+            }
+            Console.WriteLine($"************");
             ParameterGroups = Variants.ToParameterGroups().OrderBy(pg => pg.OrderCategory).ThenByDescending(pg => pg.IsMandatory).ToArray();
             var aliasDuplicates = ParameterGroups.SelectMany(pg => pg.Aliases)
                 //https://stackoverflow.com/a/18547390/294804

--- a/powershell/resources/psruntime/Helpers/ResponseHeaderHelper.cs
+++ b/powershell/resources/psruntime/Helpers/ResponseHeaderHelper.cs
@@ -1,18 +1,17 @@
 using System.Net.Http;
 using System.Collections.Generic;
-using Microsoft.Graph.PowerShell.ResponseHeaders;
 
 namespace Microsoft.Graph.PowerShell.ResponseHeader.Helper
 {
     public static class ResponseHeaderHelper
     {
 
-        public static ResponseHeader ToResponseHeader(HttpResponseMessage response)
+        public static Microsoft.Graph.PowerShell.ResponseHeaders.ResponseHeader ToResponseHeader(HttpResponseMessage response)
 
         {
             var responseHeaders = response.Headers.GetEnumerator();
-            ResponseHeaderProperties props = new ResponseHeaderProperties();
-            var headers = new List<ResponseHeaderProperties>();
+            var props = new Microsoft.Graph.PowerShell.ResponseHeaders.ResponseHeaderProperties();
+            var headers = new List<Microsoft.Graph.PowerShell.ResponseHeaders.ResponseHeaderProperties>();
             while (responseHeaders.MoveNext())
             {
                 var header = responseHeaders.Current;
@@ -27,7 +26,7 @@ namespace Microsoft.Graph.PowerShell.ResponseHeader.Helper
 
             headers.Add(props);
 
-            return new ResponseHeader { ResponseHeaders = headers };
+            return new Microsoft.Graph.PowerShell.ResponseHeaders.ResponseHeader { ResponseHeaders = headers };
         }
     }
 }

--- a/powershell/resources/psruntime/Helpers/ResponseHeaderHelper.cs
+++ b/powershell/resources/psruntime/Helpers/ResponseHeaderHelper.cs
@@ -1,0 +1,33 @@
+using System.Net.Http;
+using System.Collections.Generic;
+using Microsoft.Graph.PowerShell.ResponseHeaders;
+
+namespace Microsoft.Graph.PowerShell.ResponseHeader.Helper
+{
+    public static class ResponseHeaderHelper
+    {
+
+        public static ResponseHeader ToResponseHeader(HttpResponseMessage response)
+
+        {
+            var responseHeaders = response.Headers.GetEnumerator();
+            ResponseHeaderProperties props = new ResponseHeaderProperties();
+            var headers = new List<ResponseHeaderProperties>();
+            while (responseHeaders.MoveNext())
+            {
+                var header = responseHeaders.Current;
+                var propName = header.Key.Replace("-", "_");
+                var propValue = string.Join(",", header.Value);
+                if (props.GetType().GetProperty(propName) != null)
+                {
+                    props.GetType().GetProperty(propName).SetValue(props, propValue);
+
+                }
+            }
+
+            headers.Add(props);
+
+            return new ResponseHeader { ResponseHeaders = headers };
+        }
+    }
+}

--- a/powershell/resources/psruntime/ResponseHeader.cs
+++ b/powershell/resources/psruntime/ResponseHeader.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+namespace Microsoft.Graph.PowerShell.ResponseHeaders
+{
+    class ResponseHeader
+    {
+        public List<ResponseHeaderProperties> ResponseHeaders { get; set; }
+
+    }
+
+    class ResponseHeaderProperties
+    {
+        public string Date { get; set; }
+        public string request_id { get; set; }
+        public string client_request_id { get; set; }
+        public string x_ms_ags_diagnostic { get; set; }
+        public string Strict_Transport_Security { get; set; }
+        public string Cache_Control { get; set; }
+        public string Pragma { get; set; }
+        public string OData_Version { get; set; }
+        public string Vary { get; set; }
+        public string Location { get; set; }
+        public string x_ms_resource_unit { get; set; }
+        public string Content_Type { get; set; }
+        public string Content_Location { get; set; }
+        public string Content_Length { get; set; }
+    }
+}

--- a/powershell/resources/psruntime/ResponseHeader.cs
+++ b/powershell/resources/psruntime/ResponseHeader.cs
@@ -1,13 +1,13 @@
 using System.Collections.Generic;
 namespace Microsoft.Graph.PowerShell.ResponseHeaders
 {
-    class ResponseHeader
+    public class ResponseHeader
     {
         public List<ResponseHeaderProperties> ResponseHeaders { get; set; }
 
     }
 
-    class ResponseHeaderProperties
+    public class ResponseHeaderProperties
     {
         public string Date { get; set; }
         public string request_id { get; set; }


### PR DESCRIPTION
This PR

- enables users to capture response headers and assign them to a variable in a powershell session which is ideal for requests that have location headers in the response header. For example, https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2561.
- supports long running operations. For example https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/897
 