### PR TITLE
Makes response header optional and assigns it to a  variable in a powershell session as long as the ``-RHV`` paramater is provided

### DIFF
--- a/powershell/resources/runtime/csharp/json/Helpers/ResponseHeaderHelper.cs
+++ b/powershell/resources/runtime/csharp/json/Helpers/ResponseHeaderHelper.cs
@@ -1,0 +1,36 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Microsoft.Graph.PowerShell.ResponseHeaders.Helpers
+{
+    internal static class ResponseHeaderHelper
+    {
+        internal static Dictionary<string, IEnumerable<string>> GetHttpResponseHeaders(HttpResponseMessage response)
+        {
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var entry in response.Headers)
+            {
+                headers[entry.Key] = entry.Value;
+            }
+
+            // In CoreFX, HttpResponseMessage separates content related headers, such as Content-Type to
+            // HttpResponseMessage.Content.Headers. The remaining headers are in HttpResponseMessage.Headers.
+            // The keys in both should be unique with no duplicates between them.
+            // Added for backwards compatibility with PowerShell 5.1 and earlier.
+            if (response.Content != null)
+            {
+                foreach (var entry in response.Content.Headers)
+                {
+                    headers[entry.Key] = entry.Value;
+                }
+            }
+
+            return headers;
+        }
+    }
+}


### PR DESCRIPTION
<img width="799" alt="image" src="https://github.com/microsoftgraph/autorest.powershell/assets/10947120/625e51e1-f69f-4466-ab34-57301cd1cd67">
<img width="701" alt="image" src="https://github.com/microsoftgraph/autorest.powershell/assets/10947120/082eaafb-c4e3-4f75-8dda-12ec059c102d">
