### PR TITLE
Replaces ``Microsoft.Win32.Registry`` with a Media Type Helper Class

### DIFF
--- a/powershell/llcsharp/operation/method.ts
+++ b/powershell/llcsharp/operation/method.ts
@@ -344,10 +344,8 @@ export class OperationMethod extends Method {
           yield `System.IO.FileStream fileStream = body as System.IO.FileStream;`
           yield `string fileExtension = System.IO.Path.GetExtension(fileStream.Name);`
           yield EOL;
-          yield `// get mime type from registry`
-          yield `string mimeType = "application/octet-stream";`
-          yield `Microsoft.Win32.RegistryKey regKey = Microsoft.Win32.Registry.ClassesRoot.OpenSubKey(fileExtension);`
-          yield `if (regKey != null && regKey.GetValue("Content Type") != null) mimeType = regKey.GetValue("Content Type").ToString();`
+          yield `// get mime type from helper`
+          yield `string mimeType = Microsoft.Graph.PowerShell.MimeTypes.Helpers.MimeTypesHelper.GetContentType(fileExtension);`
           yield EOL;
           yield '// set body content';
           yield `request.Content = new System.Net.Http.StreamContent(body);`;

--- a/powershell/resources/runtime/csharp/json/Helpers/MimeTypesHelper.cs
+++ b/powershell/resources/runtime/csharp/json/Helpers/MimeTypesHelper.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+namespace Microsoft.Graph.PowerShell.MimeTypes.Helpers
+{
+    /// <summary>
+    /// Helps with Mime Types
+    /// </summary>
+    public static class MimeTypesHelper
+    {
+        /// <summary>
+        /// Returns the content type based on the given file extension.
+        /// <see cref="https://www.iana.org/assignments/media-types/media-types.xhtml"/>
+        /// </summary>
+        public static string GetContentType(string fileExtension)
+        {
+            var mimeTypes = new Dictionary<String, String>
+            {
+                {".bmp", "image/bmp"},
+                {".gif", "image/gif"},
+                {".jpeg", "image/jpeg"},
+                {".jpg", "image/jpeg"},
+                {".png", "image/png"},
+                {".tif", "image/tiff"},
+                {".tiff", "image/tiff"},
+                {".doc", "application/msword"},
+                {".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
+                {".pdf", "application/pdf"},
+                {".ppt", "application/vnd.ms-powerpoint"},
+                {".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"},
+                {".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+                {".xls", "application/vnd.ms-excel"},
+                {".csv", "text/csv"},
+                {".xml", "text/xml"},
+                {".txt", "text/plain"},
+                {".zip", "application/zip"},
+                {".rar", "application/x-rar-compressed"},
+                {".7z", "application/x-7z-compressed"},
+                {".gz", "application/gzip"},
+                {".tar", "application/x-tar"},
+                {".mp3", "audio/mpeg"},
+                {".wav", "audio/wav"},
+                {".mp4", "video/mp4"},
+                {".avi", "video/x-msvideo"},
+                {".wmv", "video/x-ms-wmv"},
+                {".flv", "video/x-flv"},
+                {".mov", "video/quicktime"},
+                {".mkv", "video/x-matroska"},
+                {".webm", "video/webm"},
+                {".ogg", "video/ogg"},
+                {".ogv", "video/ogg"},
+                {".webp", "image/webp"},
+                {".svg", "image/svg+xml"},
+                {".json", "application/json"},
+                {".html", "text/html"},
+                {".htm", "text/html"},
+                {".css", "text/css"},
+                {".js", "application/javascript"},
+                {".ts", "video/mp2t"},
+                {".wasm", "application/wasm"},
+                {".ico", "image/x-icon"},
+                {".cur", "image/x-icon"}
+            };
+
+            // if the file type is not recognized, return default"application/octet-stream"
+            return mimeTypes.ContainsKey(fileExtension) ? mimeTypes[fileExtension] : "application/octet-stream";
+        }
+    }
+}

--- a/powershell/resources/runtime/csharp/json/Helpers/MimeTypesHelper.cs
+++ b/powershell/resources/runtime/csharp/json/Helpers/MimeTypesHelper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Graph.PowerShell.MimeTypes.Helpers
                 {".js", "application/javascript"}
             };
 
-            // if the file type is not recognized, return default"application/octet-stream"
+            // if the file type is not recognized, return default "application/octet-stream"
             return mimeTypes.ContainsKey(fileExtension) ? mimeTypes[fileExtension] : "application/octet-stream";
         }
     }

--- a/powershell/resources/runtime/csharp/json/Helpers/MimeTypesHelper.cs
+++ b/powershell/resources/runtime/csharp/json/Helpers/MimeTypesHelper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Graph.PowerShell.MimeTypes.Helpers
                 {".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"},
                 {".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
                 {".xls", "application/vnd.ms-excel"},
-                {".ico", "image/vnd.microsoft.icon"}
+                {".ico", "image/vnd.microsoft.icon"},
                 {".csv", "text/csv"},
                 {".xml", "text/xml"},
                 {".txt", "text/plain"},

--- a/powershell/resources/runtime/csharp/json/Helpers/MimeTypesHelper.cs
+++ b/powershell/resources/runtime/csharp/json/Helpers/MimeTypesHelper.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Graph.PowerShell.MimeTypes.Helpers
                 {".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"},
                 {".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
                 {".xls", "application/vnd.ms-excel"},
+                {".ico", "image/vnd.microsoft.icon"}
                 {".csv", "text/csv"},
                 {".xml", "text/xml"},
                 {".txt", "text/plain"},
@@ -37,28 +38,13 @@ namespace Microsoft.Graph.PowerShell.MimeTypes.Helpers
                 {".7z", "application/x-7z-compressed"},
                 {".gz", "application/gzip"},
                 {".tar", "application/x-tar"},
-                {".mp3", "audio/mpeg"},
-                {".wav", "audio/wav"},
-                {".mp4", "video/mp4"},
-                {".avi", "video/x-msvideo"},
-                {".wmv", "video/x-ms-wmv"},
-                {".flv", "video/x-flv"},
-                {".mov", "video/quicktime"},
-                {".mkv", "video/x-matroska"},
-                {".webm", "video/webm"},
-                {".ogg", "video/ogg"},
-                {".ogv", "video/ogg"},
                 {".webp", "image/webp"},
                 {".svg", "image/svg+xml"},
                 {".json", "application/json"},
                 {".html", "text/html"},
                 {".htm", "text/html"},
                 {".css", "text/css"},
-                {".js", "application/javascript"},
-                {".ts", "video/mp2t"},
-                {".wasm", "application/wasm"},
-                {".ico", "image/x-icon"},
-                {".cur", "image/x-icon"}
+                {".js", "application/javascript"}
             };
 
             // if the file type is not recognized, return default"application/octet-stream"


### PR DESCRIPTION
**Issue to be fixed**
``Set-MgUserPhotoContent`` not working in PowerShell 5 as reported [here](https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2645).
**Changes proposed**
Introduced a helper class for assigning the correct media type instead of relying on the ``Microsoft.Win32.Registry`` class which only works with PowerShell Core (PowerShell 7) but not PowerShell 5 ( a .NET framework application).
``Microsoft.Win32.Registry`` supports .NET standard which is used to build PowerShell SDK cmdlets but it is a runtime specific package. 
.NET Core knows how to find runtime specific assets, while .NET Framework doesn't.
**How to test**

- While in a PowerShell 5 session, install the SDK from an internal feed and test the functionality.  Installation instructions can be found [here](https://microsoft.sharepoint-df.com/:o:/t/GraphTooling/EiAJuxfQZihEnoYlCfzU3k8BG6Uqhey7eM51K_VdUBbB-g?e=R7yvqx).
- connect to graph using ``connect-mggraph -scopes "ProfilePhoto.ReadWrite.All"``
- Test the commandlet ``Set-MgUserPhotoContent -UserId <Your user Id> -InFile "<Path to your image file>" -Debug

**Expected outcome**
- The cmldet should not throw an error related to ``Microsoft.Win32.Registry`` assembly.
<img width="955" alt="image" src="https://github.com/microsoftgraph/autorest.powershell/assets/10947120/563597b7-455b-48fd-8ce0-e4cb978c33d6">
