### PR TITLE
Implementation for external docs support

### DIFF
--- a/powershell/autorest-configuration.md
+++ b/powershell/autorest-configuration.md
@@ -12,13 +12,14 @@ modelerfour:
   additional-checks: false
   always-create-content-type-parameter: false
   always-seal-x-ms-enums: true
+  treat-type-object-as-anything: true
 ```
 
 > if the modeler is loaded already, use that one, otherwise grab it.
 
 ``` yaml !isLoaded('@autorest/modelerfour')
 use-extension:
-  "@autorest/modelerfour": "4.15.414"
+  "@autorest/modelerfour": "4.24.3"
 
 # will use highest 2.0.x 
 ```

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -14,7 +14,7 @@ import {
   Switch, System, TerminalCase, toExpression, Try, Using, valueOf, Field, IsNull, Or, ExpressionOrLiteral, TerminalDefaultCase, xmlize, TypeDeclaration, And, IsNotNull, PartialMethod, Case, While
 } from '@azure-tools/codegen-csharp';
 import { ClientRuntime, EventListener, Schema, ArrayOf, EnumImplementation } from '../llcsharp/exports';
-import { Alias, ArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum, GeneratedAttribute, DescriptionAttribute, CategoryAttribute, ParameterCategory, ProfileAttribute, PSObject, InternalExportAttribute, ExportAsAttribute, DefaultRunspace, RunspaceFactory, AllowEmptyCollectionAttribute, DoNotExportAttribute } from '../internal/powershell-declarations';
+import { Alias, ArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum, GeneratedAttribute, DescriptionAttribute, ExternalDocsAttribute, CategoryAttribute, ParameterCategory, ProfileAttribute, PSObject, InternalExportAttribute, ExportAsAttribute, DefaultRunspace, RunspaceFactory, AllowEmptyCollectionAttribute, DoNotExportAttribute } from '../internal/powershell-declarations';
 import { State } from '../internal/state';
 import { Channel } from '@azure-tools/autorest-extension-base';
 import { IParameter } from '@azure-tools/codemodel-v3/dist/code-model/components';
@@ -1793,6 +1793,14 @@ export class CmdletClass extends Class {
     }
 
     this.add(new Attribute(DescriptionAttribute, { parameters: [new StringExpression(this.description)] }));
+    //If defines external docs for operation
+    if (operation.details.default.externalDocs) {
+      this.add(new Attribute(ExternalDocsAttribute, {
+        parameters: [`${new StringExpression(this.operation.details.default.externalDocs?.url ?? "")}`,
+        `${new StringExpression(this.operation.details.default.externalDocs?.description ?? "")}`
+        ]
+      }));
+    }
     this.add(new Attribute(GeneratedAttribute));
     if (operation.extensions && operation.extensions['x-ms-metadata'] && operation.extensions['x-ms-metadata'].profiles) {
       const profileNames = Object.keys(operation.extensions && operation.extensions['x-ms-metadata'].profiles);

--- a/powershell/internal/powershell-declarations.ts
+++ b/powershell/internal/powershell-declarations.ts
@@ -40,6 +40,7 @@ export const AsyncCommandRuntime = new ClassType(ClientRuntime, 'PowerShell.Asyn
 export const AsyncJob = new ClassType(ClientRuntime, 'PowerShell.AsyncJob');
 
 export const DescriptionAttribute: TypeDeclaration = new ClassType(rest, 'Description');
+export const ExternalDocsAttribute: TypeDeclaration = new ClassType(rest, 'ExternalDocs');
 export const DoNotExportAttribute: TypeDeclaration = new ClassType(rest, 'DoNotExport');
 export const InternalExportAttribute: TypeDeclaration = new ClassType(rest, 'InternalExport');
 export const GeneratedAttribute: TypeDeclaration = new ClassType(rest, 'Generated');

--- a/powershell/llcsharp/schema/schema-resolver.ts
+++ b/powershell/llcsharp/schema/schema-resolver.ts
@@ -20,6 +20,7 @@ import { EnumImplementation } from './enum';
 import { Numeric } from './integer';
 import { ObjectImplementation } from './object';
 import { String } from './string';
+import { Uri } from './uri';
 import { Uuid } from './Uuid';
 import { EnhancedTypeDeclaration } from './extended-type-declaration';
 import { PwshModel } from '../../utils/PwshModel';
@@ -73,6 +74,8 @@ export class SchemaDefinitionResolver {
         return new Duration(<DurationSchema>schema, required);
       case SchemaType.Uuid:
         return new Uuid(<StringSchema>schema, required);
+      case SchemaType.Uri:
+        return new Uri(<StringSchema>schema, required);
       case SchemaType.DateTime:
         if ((<DateTimeSchema>schema).format === StringFormat.DateTimeRfc1123) {
           return new DateTime1123(<DateTimeSchema>schema, required);

--- a/powershell/llcsharp/schema/uri.ts
+++ b/powershell/llcsharp/schema/uri.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { nameof } from '@azure-tools/codegen';
+import { Variable } from '@azure-tools/codegen-csharp';
+import { Schema } from '../code-model';
+import { StringSchema } from '@azure-tools/codemodel';
+import { String } from './string';
+
+
+export class Uri extends String {
+  constructor(schema: StringSchema, isRequired: boolean) {
+    super(schema, isRequired);
+  }
+
+  get declaration(): string {
+    return 'string';
+  }
+  public validatePresence(eventListener: Variable, property: Variable): string {
+    return this.isRequired ? `await ${eventListener}.AssertNotNull(${nameof(property.value)},${property});`.trim() : '';
+  }
+  validateValue(eventListener: Variable, property: Variable): string {
+    return `await ${eventListener}.AssertRegEx(${nameof(property.value)},${property},@"^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$");`;
+  }
+}

--- a/powershell/plugins/create-commands-v2.ts
+++ b/powershell/plugins/create-commands-v2.ts
@@ -19,7 +19,7 @@ import { CommandOperation } from '../utils/command-operation';
 
 type State = ModelState<PwshModel>;
 
-const specialWords : { [key: string]: Array<string> } = {in: <Array<string>>['sign']};
+const specialWords: { [key: string]: Array<string> } = { in: <Array<string>>['sign'] };
 
 // UNUSED: Moved to plugin-tweak-model.ts in remodeler
 // For now, we are not dynamically changing the service-name. Instead, we would figure out a method to change it during the creation of service readme's.
@@ -39,7 +39,6 @@ pluralizationService.addWord('Database', 'Databases');
 pluralizationService.addWord('database', 'databases');
 pluralizationService.addWord('Premise', 'Premises');
 pluralizationService.addWord('premise', 'premises');
-
 
 
 interface CommandVariant {
@@ -73,12 +72,12 @@ function filterSpecialWords(preposition: string, parts: Array<string>) {
   if (specialWords[preposition] !== undefined) {
     do {
       idx = parts.indexOf(preposition, start);
-      if (idx <= 0 || !specialWords[preposition].includes(parts[idx -1])) {
+      if (idx <= 0 || !specialWords[preposition].includes(parts[idx - 1])) {
         return idx;
       } else {
         start = idx + 1;
       }
-    // eslint-disable-next-line no-constant-condition
+      // eslint-disable-next-line no-constant-condition
     } while (true);
   }
   return parts.indexOf(preposition);
@@ -393,7 +392,8 @@ export /* @internal */ class Inferrer {
           subjectPrefix: variant.subjectPrefix,
           verb: variant.verb,
           name: vname,
-          alias: variant.alias
+          alias: variant.alias,
+          externalDocs: operation.externalDocs
         }
       },
       // operationId is not needed any more

--- a/powershell/resources/psruntime/Attributes/ExternalDocsAttribute.cs
+++ b/powershell/resources/psruntime/Attributes/ExternalDocsAttribute.cs
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+namespace Microsoft.Rest
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+    public class ExternalDocsAttribute : Attribute
+    {
+
+        public string Description { get; }
+
+        public string Url { get; }
+
+        public ExternalDocsAttribute(string url)
+        {
+            Url = url;
+        }
+
+        public ExternalDocsAttribute(string url, string description)
+        {
+            Url = url;
+            Description = description;
+        }
+    }
+}

--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
@@ -357,6 +357,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var notesText = !String.IsNullOrEmpty(notes) ? $"{Environment.NewLine}.Notes{Environment.NewLine}{ComplexParameterHeader}{notes}" : String.Empty;
             var relatedLinks = String.Join(Environment.NewLine, CommentInfo.RelatedLinks.Select(l => $".Link{Environment.NewLine}{l}"));
             var relatedLinksText = !String.IsNullOrEmpty(relatedLinks) ? $"{Environment.NewLine}{relatedLinks}" : String.Empty;
+            var externalUrls = String.Join(Environment.NewLine, CommentInfo.ExternalUrls.Select(l => $".Link{Environment.NewLine}{l}"));
+            var externalUrlsText = !String.IsNullOrEmpty(externalUrls) ? $"{Environment.NewLine}{externalUrls}" : String.Empty;
             var examples = "";
             foreach (var example in VariantGroup.HelpInfo.Examples)
             {
@@ -369,7 +371,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 {CommentInfo.Description.ToDescriptionFormat(false)}
 {examples}{inputsText}{outputsText}{notesText}
 .Link
-{CommentInfo.OnlineVersion}{relatedLinksText}
+{CommentInfo.OnlineVersion}{relatedLinksText}{externalUrlsText}
 #>
 ";
         }

--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyTypes.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyTypes.cs
@@ -374,6 +374,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
         public string OnlineVersion { get; }
         public string[] RelatedLinks { get; }
+        public string[] ExternalUrls { get; }
 
         private const string HelpLinkPrefix = @"${$project.helpLinkPrefix}";
 
@@ -399,6 +400,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var moduleName = variantGroup.RootModuleName == "" ? variantGroup.ModuleName.ToLowerInvariant() : variantGroup.RootModuleName.ToLowerInvariant();
             OnlineVersion = helpInfo.OnlineVersion?.Uri.NullIfEmpty() ?? $@"{HelpLinkPrefix}{moduleName}/{variantGroup.CmdletName.ToLowerInvariant()}";
             RelatedLinks = helpInfo.RelatedLinks.Select(rl => rl.Text).ToArray();
+            // Get external urls from attribute
+            ExternalUrls = variantGroup.Variants.SelectMany(v => v.Attributes).OfType<ExternalDocsAttribute>()?.Select(e => e.Url)?.Distinct()?.ToArray();
         }
     }
 

--- a/powershell/utils/components.ts
+++ b/powershell/utils/components.ts
@@ -98,6 +98,9 @@ export interface ImplementationDetails extends Dictionary<any> {
 
   /** message used to go along with deprecation */
   deprecationMessage?: string;
+
+  /** external docs description */
+  externalDocs?: ExternalDocumentation;
 }
 
 export enum ImplementationLocation {


### PR DESCRIPTION
Implemented external docs support i.e.  Linking a cmdlet to the API reference page.

Fixes https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/876
**Changes proposed**
1. Updated autorest modelerfour extension to 4.24.3 version in ``autorest-configuration.md`` The extension has provision for picking up the externalDocsUrl parameter from openApi paths.
2. Update ``class.ts`` that defines external docs for an operation. Injects description and external docs properties into cmdlet classes.
3. Add ``ExternalDocs`` declaration to ``powershell-declaration.ts``
4. Add Uri schema resolver
5. Updated MarkDownTypes to incooperate the external docs link.

The outcome of the proposed changes are shown in the screenshots below.

**Find-MgGraphCommand**
<img width="733" alt="image" src="https://github.com/microsoftgraph/autorest.powershell/assets/10947120/20f5a34d-1e38-46db-9174-7ca1a92eff1c">

**Offline Help**
<img width="945" alt="image" src="https://github.com/microsoftgraph/autorest.powershell/assets/10947120/bf091a69-fea1-45d1-a79c-0444d5673487">

