### PR TITLE
Bump pnpm version to fix vulnerable transitive dependencies

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -24,7 +24,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "8.14.1",
+  "pnpmVersion": "8.15.9",
   /**
    * Options that are only used when the PNPM package manager is selected
    */


### PR DESCRIPTION
Bumps package manager to fix vulnerable transitive dependencies that are still being flagged.

Version `8.15.9`:
- removes the vulnerable `ip` package (fix introduced in [`8.15.3`](https://github.com/pnpm/pnpm/blob/v8.15.9/pnpm/CHANGELOG.md#8153))
- Upgrades `tar` to `6.2.1` (fix introduced in [`8.15.8`](https://github.com/pnpm/pnpm/blob/v8.15.9/pnpm/CHANGELOG.md#8158)

Testing:
`rush update --purge`
`rush rebuild`
`rush test`
`.\tools\GenerateModules.ps1 -ModuleToGenerate Users -ApiVersion v1.0 -Build -ExcludeExampleTemplates -ExcludeNotesSection` successfully generates the Users module locally.