### PR TITLE
Updates implementation of allowing null valued properties to handle array and object schema types differently.

### DIFF
--- a/powershell/llcsharp/operation/method.ts
+++ b/powershell/llcsharp/operation/method.ts
@@ -350,14 +350,23 @@ export class OperationMethod extends Method {
           yield 'request.Content = new System.Net.Http.StreamContent(body);';
           yield 'request.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(!string.IsNullOrEmpty(contentType)? contentType : mimeType);';
         } else {
-          // This block is only supposed to be applied on requests that have a body parameter
-          if (method.capitalize() === 'Post' || method.capitalize() === 'Put' || method.capitalize() === 'Patch') {
+
+          if (bp.typeDeclaration.schema.type === 'object' && (method.capitalize() === 'Post' || method.capitalize() === 'Put' || method.capitalize() === 'Patch')) {
             yield 'string cleanedBody = "@{}";';
             yield 'if (body != null) {';
             yield '    cleanedBody = body.ToJson(null).ToString();';
             yield '    cleanedBody = Microsoft.Graph.PowerShell.JsonUtilities.JsonExtensions.ReplaceAndRemoveSlashes(cleanedBody);';
             yield '    Newtonsoft.Json.Linq.JObject jsonObject = Newtonsoft.Json.Linq.JObject.Parse(cleanedBody);';
             yield '    cleanedBody = Microsoft.Graph.PowerShell.JsonUtilities.JsonExtensions.RemoveDefaultNullProperties(jsonObject);';
+            yield '}';
+            yield EOL;
+          } else if (bp.typeDeclaration.schema.type === 'array' && (method.capitalize() === 'Post' || method.capitalize() === 'Put' || method.capitalize() === 'Patch')) {
+            yield 'string cleanedBody = "@[{}]";';
+            yield 'if (body != null) {';
+            yield '    cleanedBody = new Microsoft.Graph.PowerShell.Runtime.Json.XNodeArray(global::System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Select(body, (__x) => __x?.ToJson(null, Microsoft.Graph.PowerShell.Runtime.SerializationMode.None)))).ToString();';
+            yield '    cleanedBody = Microsoft.Graph.PowerShell.JsonUtilities.JsonExtensions.ReplaceAndRemoveSlashes(cleanedBody);';
+            yield '    Newtonsoft.Json.Linq.JArray jsonArray = Newtonsoft.Json.Linq.JArray.Parse(cleanedBody);';
+            yield '    cleanedBody = Microsoft.Graph.PowerShell.JsonUtilities.JsonExtensions.RemoveDefaultNullProperties(jsonArray);';
             yield '}';
             yield EOL;
           }


### PR DESCRIPTION
The previous implementation as per the PR [here](https://github.com/microsoftgraph/autorest.powershell/pull/9) was only handling the default ``object`` schema type and when it met an ```array``` schema type, it was throwing an error.

<img width="629" alt="image" src="https://github.com/user-attachments/assets/f285b618-29af-46ff-aa8c-7afa90d9a5f4" />

The update ensures that body parameters packaged as a json array are also being considered.