### PR TITLE
chore(deps): fix js-yaml CVE for versions < 3.14.2 and < 4.1.1

### DIFF
--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -8,6 +8,19 @@ function readPackage(pkg, context) {
       `Overriding serialize-javascript from ${old} to ^7.0.3 in ${pkg.name}`
     );
   }
+  if (pkg.dependencies && pkg.dependencies["js-yaml"]) {
+    const ver = pkg.dependencies["js-yaml"];
+    // Override exact js-yaml 3.x < 3.14.2
+    if (/^3\.(\d+)\.(\d+)$/.test(ver) && ver !== "3.14.2") {
+      pkg.dependencies["js-yaml"] = "3.14.2";
+      context.log(`Overriding js-yaml from ${ver} to 3.14.2 in ${pkg.name}`);
+    }
+    // Override js-yaml 4.x < 4.1.1
+    if (/^[~^]?4\./.test(ver) && ver !== "4.1.1" && ver !== "^4.1.0") {
+      pkg.dependencies["js-yaml"] = "4.1.1";
+      context.log(`Overriding js-yaml from ${ver} to 4.1.1 in ${pkg.name}`);
+    }
+  }
   return pkg;
 }
 

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -60,8 +60,8 @@ dependencies:
     specifier: ~8.57.0
     version: 8.57.1
   js-yaml:
-    specifier: 3.13.1
-    version: 3.13.1
+    specifier: 3.14.2
+    version: 3.14.2
   mocha:
     specifier: 10.7.3
     version: 10.7.3
@@ -90,7 +90,7 @@ packages:
     deprecated: 'Warning: This package has been renamed to ''@autorest/extension-base'', please use ''@autorest/extension-base'' instead.'
     dependencies:
       '@azure-tools/codegen': 2.5.294
-      js-yaml: 3.13.1
+      js-yaml: 3.14.2
       vscode-jsonrpc: 3.6.2
     dev: false
 
@@ -107,7 +107,7 @@ packages:
     dependencies:
       '@azure-tools/async-io': 3.0.254
       '@azure-tools/linq': 3.1.263
-      js-yaml: 4.0.0
+      js-yaml: 4.1.1
       semver: 5.7.2
     dev: false
 
@@ -966,19 +966,12 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: false
 
-  /js-yaml@3.13.1:
-    resolution: {integrity: sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==}
+  /js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-    dev: false
-
-  /js-yaml@4.0.0:
-    resolution: {integrity: sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==}
-    hasBin: true
-    dependencies:
-      argparse: 2.0.1
     dev: false
 
   /js-yaml@4.1.1:
@@ -1441,7 +1434,7 @@ packages:
     dev: false
 
   file:projects/powershell.tgz:
-    resolution: {integrity: sha512-vscLsY1UCMRPoUmJwTqlza09kF9luS9IjguT8eezrqtznOnFIgur6onrSAoE8gT6MdD4Ho07O14BjFZn6rQSpQ==, tarball: file:projects/powershell.tgz}
+    resolution: {integrity: sha512-7Tz7nmUFfqun+VDaZo3rmiATw5QUcm0Gcdl2BCipQMBdpw3gWfCzo+GKqyJEfFap2vlTwnMmIgaskXapnJYKYA==, tarball: file:projects/powershell.tgz}
     name: '@rush-temp/powershell'
     version: 0.0.0
     dependencies:
@@ -1462,7 +1455,7 @@ packages:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@3.9.10)
       autorest: 3.0.6339
       eslint: 8.57.1
-      js-yaml: 3.13.1
+      js-yaml: 3.14.2
       mocha: 10.7.3
       source-map-support: 0.5.13
       typescript: 3.9.10


### PR DESCRIPTION
## Summary

Fixes vulnerable transitive \js-yaml\ dependencies by adding overrides to the \.pnpmfile.cjs\ hook.

### Changes
- **\js-yaml@3.13.1\** (from \@azure-tools/autorest-extension-base\) → overridden to **3.14.2**
- **\js-yaml@4.0.0\** (from \@azure-tools/codegen\ via \~4.0.0\) → overridden to **4.1.1**

### Why a hook?
These are transitive dependencies pinned by upstream packages. Since there are no updated releases of \@azure-tools/autorest-extension-base\ or \@azure-tools/codegen\ that bump js-yaml, the \.pnpmfile.cjs\ \
eadPackage\ hook is the only way to override them without forking.

Build and tests pass successfully.

Closes https://github.com/microsoftgraph/autorest.powershell/security/dependabot/32
Closes https://github.com/microsoftgraph/autorest.powershell/security/dependabot/33
