### PR TITLE
fix: buffer ProxyCmdletDefinitions.ps1 writes to avoid IOException file locks

### DIFF
--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 ${$project.pwshCommentHeaderForCsharp}
 # ----------------------------------------------------------------------------------
 ");
-                HashSet<string> LicenseSet = new HashSet<string>();
+                var proxyDefinitions = new Dictionary<string, StringBuilder>();
                 foreach (var variantGroup in variantGroups)
                 {
                     var parameterGroups = variantGroup.ParameterGroups.ToList();
@@ -132,15 +132,18 @@ ${$project.pwshCommentHeaderForCsharp}
                     sb.Append($"}}{Environment.NewLine}");
 
                     Directory.CreateDirectory(variantGroup.OutputFolder);
-                    File.WriteAllText(variantGroup.FilePath, license.ToString());
-                    File.AppendAllText(variantGroup.FilePath, sb.ToString());
-                    if (!LicenseSet.Contains(Path.Combine(variantGroup.OutputFolder, "ProxyCmdletDefinitions.ps1")))
+                    File.WriteAllText(variantGroup.FilePath, license.ToString() + sb.ToString());
+                    var proxyPath = Path.Combine(variantGroup.OutputFolder, "ProxyCmdletDefinitions.ps1");
+                    if (!proxyDefinitions.ContainsKey(proxyPath))
                     {
-                        // only add license in the header
-                        File.AppendAllText(Path.Combine(variantGroup.OutputFolder, "ProxyCmdletDefinitions.ps1"), license.ToString());
-                        LicenseSet.Add(Path.Combine(variantGroup.OutputFolder, "ProxyCmdletDefinitions.ps1"));
+                        proxyDefinitions[proxyPath] = new StringBuilder(license.ToString());
                     }
-                    File.AppendAllText(Path.Combine(variantGroup.OutputFolder, "ProxyCmdletDefinitions.ps1"), sb.ToString());
+                    proxyDefinitions[proxyPath].Append(sb);
+                }
+
+                foreach (var entry in proxyDefinitions)
+                {
+                    File.WriteAllText(entry.Key, entry.Value.ToString());
                 }
 
                 if (!ExcludeDocs)


### PR DESCRIPTION
## Problem

\ExportProxyCmdlet\ calls \File.AppendAllText\ on \ProxyCmdletDefinitions.ps1\ once per cmdlet variant (100+ times in a loop). On Windows, antivirus or file indexers can transiently lock the file between writes, causing an \IOException\ that fails module generation.

## Fix

- Buffer all \ProxyCmdletDefinitions.ps1\ content in a \Dictionary<string, StringBuilder>\ keyed by output folder
- Write each file once after the loop via \File.WriteAllText\
- Also simplified per-cmdlet file writes to a single \File.WriteAllText\ call (was \WriteAllText\ + \AppendAllText\)

This eliminates the repeated open/close cycle that made the build vulnerable to transient file locks.