### PR TITLE
bump node supported version

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -49,7 +49,7 @@
    * Specify a SemVer range to ensure developers use a NodeJS version that is appropriate
    * for your repo.
    */
-  "nodeSupportedVersionRange": ">=8.9.4 <20.0.0",
+  "nodeSupportedVersionRange": ">=8.9.4",
   "ensureConsistentVersions": true,
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 2,


### PR DESCRIPTION
Remove node restriction so that v22 can be used. 
v22 is the current LTS version